### PR TITLE
fix(keypair): Enable keypair generation without authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ For further information please see https://safenetforum.org/t/safe-cli-high-leve
   - [Auth](#auth)
     - [Prerequisite: run the Authenticator](#prerequisite-run-the-authenticator)
     - [Authorise the safe_cli app](#authorise-the-safe_cli-app)
+  - [Key pair](#key-pair)
   - [Keys](#keys)
     - [Create](#keys-creation)
     - [Balance](#keys-balance)
-    - [Key pair generation](#key-pair-generation)
   - [Wallet](#wallet)
     - [Create](#wallet-creation)
     - [Insert](#wallet-insert)
@@ -105,6 +105,28 @@ Allow authorisation? [y/N]:
 ```
 
 
+#### Key-pair
+
+There are some scenarios that being able to generate a sign/encryption key-pair, without creating and/or storing a `Key` on the network, is required.
+
+As an example, if we want to have a friend to create a `Key` for us, and preload it with some safecoins, we can generate a key-pair, and share with our friend only the public key so they can generate the `Key` to be owned by it (this is where we can use the `--pk` argument on the `keys create` sub-command).
+
+Thus, let's see how this use case would work. First we create a key-pair:
+```shell
+$ safe_cli keypair --pretty
+Key pair generated:
+pk="b2371df48684dc9456988f45b56d7640df63895fea3d7cee45c79b26ba268d259b864330b83fa28669ab910a1725b833"
+sk="62e323615235122f7e20c7f05ddf56c5e5684853d21f65fca686b0bfb2ed851a"
+```
+
+We now take note of both the public key, and the secret key. Now, we only share the public key with our friend, who can use it to generate a `Key` to be owned by it and preload it with some test-coins:
+```shell
+$ safe_cli keys create --test-coins --preload 64.24 --pk b2371df48684dc9456988f45b56d7640df63895fea3d7cee45c79b26ba268d259b864330b83fa28669ab910a1725b833 --pretty
+New Key created at: "safe://bbkulcbmrxdx2inbg4srljrd2fwvwxmqg7moev72r5ptxelr43e25cndjf"
+```
+
+Finally, our friend gives us the XOR-URL of the `Key` they have created for us, and we can now use the `Key` for any other operation, we own the balance it contains since we have the secret key associated to it.
+
 ### Keys
 
 `Key` management allows users to generate sign/encryption key pairs that can be used for different type of operations, like choosing which sign key to use for uploading files (and therefore paying for the storage used), or signing a message posted on some social application when a `Key` is linked from a public profile (e.g. a WebID/SAFE-ID), or even for encrypting messages that are privately sent to another party so it can verify the authenticity of the sender.
@@ -144,32 +166,10 @@ Other optional args that can be used with `keys create` sub-command are:
 We can retrieve a given `Key`'s balance using its XorUrl.
 
 The target `Key` can be passed as an argument (or it will be retrieved from `stdin`)
-```shell
+```bash
 $ safe_cli keys balance safe://bbkulcbnrmdzhdkrfb6zbbf7fisbdn7ggztdvgcxueyq2iys272koaplks --pretty
 Key's current balance: 15.342
 ```
-
-#### Key pair generation
-
-There are some scenarios that being able to generate a sign/encryption key-pair, without creating and/or storing a `Key` on the network, is required.
-
-As an example, if we want to have a friend to create a `Key` for us, and preload it with some safecoins, we can generate a key-pair, and share with our friend only the public key so he can generate the `Key` to be owned by it (this is where we can use the `--pk` argument on the `keys create` sub-command).
-
-Thus, let's see how this use case would work. First we create a key-pair:
-```shell
-$ safe_cli keys keypair --pretty
-Key pair generated:
-pk="b2371df48684dc9456988f45b56d7640df63895fea3d7cee45c79b26ba268d259b864330b83fa28669ab910a1725b833"
-sk="62e323615235122f7e20c7f05ddf56c5e5684853d21f65fca686b0bfb2ed851a"
-```
-
-We now take note of both the public key, and the secret key. Now, we only share the public key with our friend, who can use it to generate a `Key` to be owned by it and preload it with some test-coins:
-```shell
-$ safe_cli keys create --test-coins --preload 64.24 --pk b2371df48684dc9456988f45b56d7640df63895fea3d7cee45c79b26ba268d259b864330b83fa28669ab910a1725b833 --pretty
-New Key created at: "safe://bbkulcbmrxdx2inbg4srljrd2fwvwxmqg7moev72r5ptxelr43e25cndjf"
-```
-
-Finally, he gives us the XOR-URL of the `Key` he created for us, and we can now use the `Key` for any other operation, we own the balance it contains since we have the secret key associated to it.
 
 ### Wallet
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,15 @@ pub fn run() -> Result<(), String> {
 
     match args.cmd {
         SubCommands::Auth { cmd } => auth_commander(cmd, &mut safe),
+        SubCommands::Keypair {} => {
+            let key_pair = safe.keys_keypair()?;
+            if pretty {
+                println!("Key pair generated:");
+            }
+            println!("pk={}", key_pair.pk);
+            println!("sk={}", key_pair.sk);
+            Ok(())
+        }
         _ => {
             // We treat SubCommands::Auth separatelly since we need to connect before
             // handling any command but auth

--- a/src/subcommands/keys.rs
+++ b/src/subcommands/keys.rs
@@ -13,9 +13,9 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 pub enum KeysSubCommands {
-    #[structopt(name = "keypair")]
-    /// Generate a key pair without creating and/or storing a Key on the network
-    Keypair {},
+    // #[structopt(name = "keypair")]
+    // /// Generate a key pair without creating and/or storing a Key on the network
+    // Keypair {},
     #[structopt(name = "create")]
     /// Create a new KeyPair
     Create {
@@ -46,15 +46,15 @@ pub fn key_commander(
 ) -> Result<(), String> {
     // Is it a create subcommand?
     match cmd {
-        Some(KeysSubCommands::Keypair {}) => {
-            let key_pair = safe.keys_keypair()?;
-            if pretty {
-                println!("Key pair generated:");
-            }
-            println!("pk={}", key_pair.pk);
-            println!("sk={}", key_pair.sk);
-            Ok(())
-        }
+        // Some(KeysSubCommands::Keypair {}) => {
+        //     // let key_pair = safe.keys_keypair()?;
+        //     // if pretty {
+        //     //     println!("Key pair generated:");
+        //     // }
+        //     // println!("pk={}", key_pair.pk);
+        //     // println!("sk={}", key_pair.sk);
+        //     Ok(())
+        // }
         Some(KeysSubCommands::Create {
             preload,
             pk,

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -50,6 +50,9 @@ pub enum SubCommands {
         #[structopt(subcommand)]
         cmd: Option<files::FilesSubCommands>,
     },
+    #[structopt(name = "keypair")]
+    /// Generate a key pair without creating and/or storing a Key on the network
+    Keypair {},
     #[structopt(name = "pns")]
     /// Manage public names on the network
     Pns {

--- a/tests/cli_keys.rs
+++ b/tests/cli_keys.rs
@@ -1,0 +1,103 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+extern crate serde_json;
+#[macro_use]
+extern crate duct;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+use std::process::Command;
+
+static CLI: &str = "safe_cli";
+static PRETTY_WALLET_CREATION_RESPONSE: &str = "Wallet created at";
+#[allow(dead_code)]
+static PRETTY_WALLET_BALANCE_EMPTY_RESPONSE: &str = "has a total balance of 0 safecoins";
+static PRETTY_KEYS_CREATION_RESPONSE: &str = "New Key created at:";
+static SAFE_PROTOCOL: &str = "safe://";
+
+fn get_bin_location() -> &'static str {
+    let mut location = "./target/release/safe_cli";
+    if cfg!(debug_assertions) {
+        location = "./target/debug/safe_cli";
+    }
+    location
+}
+
+#[test]
+fn calling_safe_keys_create_pretty() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+    cmd.args(&vec![
+        "keys",
+        "create",
+        "--test-coins",
+        "--preload",
+        "123",
+        "--pretty",
+    ])
+    .assert()
+    .stdout(predicate::str::contains(PRETTY_KEYS_CREATION_RESPONSE))
+    .stdout(predicate::str::contains(SAFE_PROTOCOL).from_utf8())
+    .success();
+}
+
+#[test]
+fn calling_safe_keys_create() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+    cmd.args(&vec!["keys", "create", "--test-coins", "--preload", "123"])
+        .assert()
+        .stdout(predicate::str::contains(PRETTY_KEYS_CREATION_RESPONSE).count(0))
+        .stdout(predicate::str::contains(SAFE_PROTOCOL).from_utf8())
+        .success();
+}
+
+#[test]
+fn calling_safe_keypair() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+    cmd.args(&vec!["keypair"])
+        .assert()
+        .stdout(predicate::str::contains("sk="))
+        .stdout(predicate::str::contains("pk="))
+        .success();
+}
+
+#[test]
+fn calling_safe_keypair_pretty() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+    cmd.args(&vec!["keypair", "--pretty"])
+        .assert()
+        .stdout(predicate::str::contains("Key pair generated:"))
+        .stdout(predicate::str::contains("sk="))
+        .stdout(predicate::str::contains("pk="))
+        .success();
+}
+
+#[test]
+fn calling_safe_keys_balance() {
+    let pk_command_result = cmd!(
+        get_bin_location(),
+        "keys",
+        "create",
+        "--test-coins",
+        "---preload",
+        "123"
+    )
+    .read()
+    .unwrap();
+
+    let mut lines = pk_command_result.lines();
+    let pk_xorurl = lines.next().unwrap();
+    assert!(pk_xorurl.contains("safe://"));
+
+    let mut cmd = Command::cargo_bin("safe_cli").unwrap();
+    cmd.args(&vec!["keys", "balance", pk_xorurl])
+        .assert()
+        .stdout("123\n")
+        .success();
+}

--- a/tests/cli_wallet.rs
+++ b/tests/cli_wallet.rs
@@ -1,0 +1,214 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+extern crate serde_json;
+#[macro_use]
+extern crate duct;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+use std::process::Command;
+
+static CLI: &str = "safe_cli";
+static PRETTY_WALLET_CREATION_RESPONSE: &str = "Wallet created at";
+#[allow(dead_code)]
+static PRETTY_WALLET_BALANCE_EMPTY_RESPONSE: &str = "has a total balance of 0 safecoins";
+static PRETTY_KEYS_CREATION_RESPONSE: &str = "New Key created at:";
+static SAFE_PROTOCOL: &str = "safe://";
+
+fn get_bin_location() -> &'static str {
+    let mut location = "./target/release/safe_cli";
+    if cfg!(debug_assertions) {
+        location = "./target/debug/safe_cli";
+    }
+    location
+}
+
+fn create_preload_and_get_keys(preload: &str) -> (String, String) {
+    // KEY_FROM
+    let pk_command_result = cmd!(
+        get_bin_location(),
+        "keys",
+        "create",
+        "--test-coins",
+        "---preload",
+        preload
+    )
+    .read()
+    .unwrap();
+
+    let mut lines = pk_command_result.lines();
+    let pk_xor = lines.next().unwrap();
+    let _pk = lines.next().unwrap();
+    let sk_line = lines.next().unwrap();
+    let sk_eq = String::from("sk=");
+    let sk = &sk_line[sk_eq.chars().count()..];
+
+    (pk_xor.to_string(), sk.to_string())
+}
+
+#[test]
+fn calling_safe_wallet_transfer() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+
+    // FROM
+    let wallet_from = cmd!(get_bin_location(), "wallet", "create").read().unwrap();
+    assert!(wallet_from.contains("safe://"));
+
+    // TO
+    let wallet_to = cmd!(get_bin_location(), "wallet", "create").read().unwrap();
+    assert!(wallet_to.contains("safe://"));
+
+    let (pk_from_xorurl, from_sk) = create_preload_and_get_keys("123");
+
+    let wallet_from_insert = cmd!(
+        get_bin_location(),
+        "wallet",
+        "insert",
+        &pk_from_xorurl,
+        &wallet_from,
+        &pk_from_xorurl,
+        "--name",
+        "our_from_wallet",
+        "--default",
+        "--secret-key",
+        &from_sk
+    )
+    .read()
+    .unwrap();
+
+    assert_eq!(&wallet_from, &wallet_from_insert);
+
+    let (pk_to_xorurl, to_sk) = create_preload_and_get_keys("3");
+
+    let wallet_to_insert = cmd!(
+        get_bin_location(),
+        "wallet",
+        "insert",
+        &pk_to_xorurl,
+        &wallet_to,
+        &pk_to_xorurl,
+        "--name",
+        "our_to_wallet",
+        "--default",
+        "--secret-key",
+        &to_sk
+    )
+    .read()
+    .unwrap();
+
+    assert_eq!(&wallet_to, &wallet_to_insert);
+
+    cmd.args(&vec![
+        "wallet",
+        "transfer",
+        "100",
+        &wallet_to,
+        &wallet_from,
+        "--pretty",
+    ])
+    .assert()
+    .stdout(predicate::str::contains("Success"))
+    .stdout(predicate::str::contains("TX_ID"))
+    .success();
+
+    // To got coins?
+    let to_has = cmd!(get_bin_location(), "wallet", "balance", &wallet_to)
+        .read()
+        .unwrap();
+
+    assert_eq!(to_has, "103");
+
+    // from lost coins?
+    let from_has = cmd!(get_bin_location(), "wallet", "balance", &wallet_from)
+        .read()
+        .unwrap();
+
+    assert_eq!(from_has, "23")
+}
+
+#[test]
+fn calling_safe_wallet_balance_pretty_no_sk() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+
+    let wallet = cmd!(get_bin_location(), "wallet", "create").read().unwrap();
+    assert!(wallet.contains("safe://"));
+
+    let (pk_to_xorurl, to_sk) = create_preload_and_get_keys("300");
+
+    let _wallet_to_insert = cmd!(
+        get_bin_location(),
+        "wallet",
+        "insert",
+        &pk_to_xorurl,
+        &wallet,
+        &pk_to_xorurl
+    )
+    .input(to_sk)
+    .read()
+    .unwrap();
+
+    cmd.args(&vec!["wallet", "balance", &wallet])
+        .assert()
+        .stdout("300\n")
+        .success();
+}
+
+#[test]
+fn calling_safe_wallet_balance() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+
+    let wallet = cmd!(get_bin_location(), "wallet", "create").read().unwrap();
+    assert!(wallet.contains("safe://"));
+
+    cmd.args(&vec![
+        "wallet", "balance", &wallet,
+        // "--pretty",
+    ])
+    .assert()
+    .stdout("0\n")
+    .success();
+}
+
+#[test]
+fn calling_safe_wallet_insert_w_preload() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+
+    let wallet = cmd!(get_bin_location(), "wallet", "create").read().unwrap();
+    assert!(wallet.contains("safe://"));
+
+    let (pk_pay_xor, _pay_sk) = create_preload_and_get_keys("300");
+
+    let _wallet_to_insert = cmd!(
+        get_bin_location(),
+        "wallet",
+        "insert",
+        &pk_pay_xor,
+        &wallet,
+        "--test-coins",
+        "--preload",
+        "150",
+    )
+    .read()
+    .unwrap();
+
+    cmd.args(&vec!["wallet", "balance", &wallet])
+        .assert()
+        .stdout("150\n")
+        .success();
+}
+
+#[test]
+fn calling_safe_wallet_create() {
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+    cmd.args(&vec!["wallet", "create", "--pretty"])
+        .assert()
+        .stdout(predicate::str::starts_with(PRETTY_WALLET_CREATION_RESPONSE).from_utf8())
+        .success();
+}


### PR DESCRIPTION
Enable keypair as own command and don't require auth for it to run